### PR TITLE
Add Office search support and modernize WinForms UI

### DIFF
--- a/FastFileFinder/FastFileFinder/Program.cs
+++ b/FastFileFinder/FastFileFinder/Program.cs
@@ -1,23 +1,23 @@
-﻿// FastFileFinder (Python backend) - .NET Framework 4.8 / C# 7.3
-// UIから python fastfilefinder_scan.py を起動し、標準出力(TSV)を逐次取り込み表示します。
+// FastFileFinder - Windows front-end for fastfilefinder_scan.py
+// .NET Framework 4.8 / C# 7.3
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace FastFileFinderPy
+namespace FastFileFinder
 {
-    static class Program
+    internal static class Program
     {
         [STAThread]
-        static void Main()
+        private static void Main()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
@@ -28,280 +28,1248 @@ namespace FastFileFinderPy
     public class SearchRow
     {
         public string Path { get; set; }
-        public string Entry { get; set; } // zip内相対パス（通常ファイルは空）
+        public string Entry { get; set; }
         public int LineNo { get; set; }
         public string Snippet { get; set; }
     }
 
     public class MainForm : Form
     {
-        TextBox txtRoot, txtQuery, txtExts, txtPython;
-        CheckBox chkRegex, chkZip, chkRecursive;
-        Button btnBrowse, btnSearch, btnCancel, btnCsv;
-        Label lblStatus;
+        private readonly TextBox txtRoot;
+        private readonly TextBox txtQuery;
+        private readonly TextBox txtExts;
+        private readonly TextBox txtPython;
+        private readonly TextBox txtPerFile;
+        private readonly TextBox txtQuickFilter;
+        private readonly CheckBox chkRegex;
+        private readonly CheckBox chkZip;
+        private readonly CheckBox chkRecursive;
+        private readonly CheckBox chkWord;
+        private readonly CheckBox chkExcel;
+        private readonly CheckBox chkLegacy;
+        private readonly NumericUpDown numMaxWorkers;
+        private readonly Button btnSearch;
+        private readonly Button btnCancel;
+        private readonly Button btnCsv;
+        private readonly Label lblElapsed;
+        private readonly Label lblFiles;
+        private readonly Label lblHits;
+        private readonly Label lblCurrent;
+        private readonly DataGridView grid;
+        private readonly Timer uiTimer;
+        private readonly Timer filterTimer;
 
-        DataGridView grid;
-        BindingList<SearchRow> binding = new BindingList<SearchRow>();
-        Process currentProc;
-        CancellationTokenSource cts;
+        private readonly List<SearchRow> allRows = new List<SearchRow>();
+        private readonly List<SearchRow> viewRows = new List<SearchRow>();
+        private readonly object rowsLock = new object();
+        private readonly Stopwatch stopwatch = new Stopwatch();
+        private readonly Color rowBack = Color.White;
+        private readonly Color rowAlt = Color.FromArgb(0xF2, 0xF4, 0xF8);
+        private readonly Color rowHover = Color.FromArgb(0xF5, 0xF9, 0xFF);
+        private readonly Color rowSelected = Color.FromArgb(0xE5, 0xF1, 0xFB);
+        private readonly Color highlightBack = Color.FromArgb(0xFF, 0xF2, 0xAB);
+
+        private Process currentProc;
+        private bool searchRunning;
+        private bool cancelRequested;
+        private string filterText = string.Empty;
+        private int hoverRow = -1;
+        private Regex highlightRegex;
+        private string highlightText = string.Empty;
+        private bool highlightIsRegex;
+        private int processedFiles;
+        private string currentFileDisplay = string.Empty;
+        private string statusMessage = string.Empty;
+        private DateTime statusMessageExpire;
 
         public MainForm()
         {
-            Text = "FastFileFinder (Python)";
-            Width = 1100; Height = 720; StartPosition = FormStartPosition.CenterScreen;
-            MinimumSize = new System.Drawing.Size(900, 520);
+            Text = "FastFileFinder";
+            Width = 1180;
+            Height = 780;
+            MinimumSize = new Size(960, 600);
+            StartPosition = FormStartPosition.CenterScreen;
             KeyPreview = true;
-            this.KeyDown += (s, e) => { if (e.KeyCode == Keys.Escape) CancelSearch(); };
+            BackColor = Color.FromArgb(0xFA, 0xFA, 0xFA);
+            Font = new Font("Meiryo UI", 9F, FontStyle.Regular, GraphicsUnit.Point, 0);
 
-            var panel = new TableLayoutPanel
+            KeyDown += (s, e) =>
             {
+                if (e.KeyCode == Keys.Escape)
+                {
+                    CancelSearch();
+                    e.Handled = true;
+                }
+            };
+
+            var mainLayout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 1,
+                RowCount = 4,
+                Padding = new Padding(0),
+            };
+            mainLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            mainLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            mainLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100));
+            mainLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+
+            var toolbar = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.LeftToRight,
+                Padding = new Padding(12, 10, 12, 4),
+                BackColor = Color.White,
+                AutoSize = true,
+            };
+
+            btnSearch = CreateToolbarButton("検索開始", Color.FromArgb(0x00, 0x78, 0xD4));
+            btnSearch.Click += async (s, e) => await StartSearchAsync();
+            toolbar.Controls.Add(btnSearch);
+
+            btnCancel = CreateToolbarButton("キャンセル (Esc)", Color.FromArgb(0xA0, 0xA0, 0xA0));
+            btnCancel.Enabled = false;
+            btnCancel.Click += (s, e) => CancelSearch();
+            toolbar.Controls.Add(btnCancel);
+
+            btnCsv = CreateToolbarButton("CSV 出力", Color.FromArgb(0x4C, 0x4C, 0x4C));
+            btnCsv.Click += (s, e) => ExportCsv();
+            toolbar.Controls.Add(btnCsv);
+
+            mainLayout.Controls.Add(toolbar, 0, 0);
+
+            var group = new GroupBox
+            {
+                Text = "検索条件",
                 Dock = DockStyle.Top,
                 AutoSize = true,
-                AutoSizeMode = AutoSizeMode.GrowAndShrink,
-                ColumnCount = 6,
-                RowCount = 5,
-                Padding = new Padding(8)
+                Padding = new Padding(12, 8, 12, 12),
+                BackColor = Color.White,
             };
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 45));
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 90));
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 55));
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
-            panel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
-            for (int i = 0; i < 5; i++) panel.RowStyles.Add(new RowStyle(SizeType.Absolute, 32));
 
-            // 1: 起点
-            panel.Controls.Add(new Label { Text = "起点フォルダ", TextAlign = System.Drawing.ContentAlignment.MiddleLeft }, 0, 0);
-            txtRoot = new TextBox { Dock = DockStyle.Fill };
-            panel.Controls.Add(txtRoot, 1, 0);
-            btnBrowse = new Button { Text = "参照" };
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 6,
+                RowCount = 6,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Padding = new Padding(0),
+            };
+
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 45));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 90));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 55));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 140));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 140));
+            for (int i = 0; i < 6; i++)
+            {
+                layout.RowStyles.Add(new RowStyle(SizeType.Absolute, 32));
+            }
+
+            layout.Controls.Add(CreateLabel("起点フォルダ"), 0, 0);
+            txtRoot = CreateTextBox();
+            layout.Controls.Add(txtRoot, 1, 0);
+            layout.SetColumnSpan(txtRoot, 2);
+
+            var btnBrowse = CreateFlatButton("参照");
             btnBrowse.Click += (s, e) => Browse();
-            panel.Controls.Add(btnBrowse, 2, 0);
-            chkRecursive = new CheckBox { Text = "サブフォルダも検索", Checked = true, AutoSize = true };
-            panel.Controls.Add(chkRecursive, 3, 0);
+            layout.Controls.Add(btnBrowse, 3, 0);
 
-            // 2: 内容フィルタ
-            panel.Controls.Add(new Label { Text = "内容フィルタ(文字列)", TextAlign = System.Drawing.ContentAlignment.MiddleLeft }, 0, 1);
-            txtQuery = new TextBox { Dock = DockStyle.Fill };
-            panel.Controls.Add(txtQuery, 1, 1);
-            chkRegex = new CheckBox { Text = "正規表現", AutoSize = true };
-            panel.Controls.Add(chkRegex, 2, 1);
-            chkZip = new CheckBox { Text = "ZIP内も検索", Checked = true, AutoSize = true };
-            panel.Controls.Add(chkZip, 3, 1);
+            chkRecursive = CreateCheckBox("サブフォルダも検索", true);
+            layout.Controls.Add(chkRecursive, 4, 0);
+            layout.SetColumnSpan(chkRecursive, 2);
 
-            // 3: 拡張子
-            panel.Controls.Add(new Label { Text = "対象拡張子(;区切り) 空=全て", TextAlign = System.Drawing.ContentAlignment.MiddleLeft }, 0, 2);
-            txtExts = new TextBox { Dock = DockStyle.Fill, Text = "" };
-            panel.Controls.Add(txtExts, 1, 2);
+            layout.Controls.Add(CreateLabel("内容フィルタ"), 0, 1);
+            txtQuery = CreateTextBox();
+            layout.Controls.Add(txtQuery, 1, 1);
+            layout.SetColumnSpan(txtQuery, 2);
 
-            // 4: Python 実行ファイル
-            panel.Controls.Add(new Label { Text = "python.exe パス (空=python)", TextAlign = System.Drawing.ContentAlignment.MiddleLeft }, 0, 3);
-            txtPython = new TextBox { Dock = DockStyle.Fill, Text = "" };
-            panel.Controls.Add(txtPython, 1, 3);
+            chkRegex = CreateCheckBox("正規表現", false);
+            layout.Controls.Add(chkRegex, 3, 1);
 
-            // 5: ボタン・ステータス
-            btnSearch = new Button { Text = "検索開始", Dock = DockStyle.Fill };
-            btnSearch.Click += async (s, e) => await StartSearchAsync();
-            panel.Controls.Add(btnSearch, 4, 3);
+            chkZip = CreateCheckBox("ZIP 内も検索", true);
+            layout.Controls.Add(chkZip, 4, 1);
 
-            btnCancel = new Button { Text = "キャンセル(Esc)", Dock = DockStyle.Fill, Enabled = false };
-            btnCancel.Click += (s, e) => CancelSearch();
-            panel.Controls.Add(btnCancel, 5, 3);
+            layout.Controls.Add(CreateLabel("対象拡張子 (;区切り)"), 0, 2);
+            txtExts = CreateTextBox();
+            layout.Controls.Add(txtExts, 1, 2);
+            layout.SetColumnSpan(txtExts, 2);
 
-            panel.Controls.Add(new Label { Text = "ステータス", TextAlign = System.Drawing.ContentAlignment.MiddleLeft }, 0, 4);
-            lblStatus = new Label { Text = "Ready", Dock = DockStyle.Fill, AutoEllipsis = true };
-            panel.Controls.Add(lblStatus, 1, 4);
+            layout.Controls.Add(CreateLabel("1 ファイル上限"), 3, 2);
+            txtPerFile = CreateTextBox();
+            txtPerFile.Width = 80;
+            layout.Controls.Add(txtPerFile, 4, 2);
 
-            btnCsv = new Button { Text = "CSV出力", Dock = DockStyle.Fill };
-            btnCsv.Click += (s, e) => ExportCsv();
-            panel.Controls.Add(btnCsv, 4, 4);
+            layout.Controls.Add(CreateLabel("並列度 (0=自動)"), 0, 3);
+            numMaxWorkers = new NumericUpDown
+            {
+                Minimum = 0,
+                Maximum = 128,
+                Value = 0,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(3, 4, 3, 4),
+            };
+            layout.Controls.Add(numMaxWorkers, 1, 3);
 
-            Controls.Add(panel);
+            layout.Controls.Add(CreateLabel("python.exe パス"), 3, 3);
+            txtPython = CreateTextBox();
+            layout.Controls.Add(txtPython, 4, 3);
+            layout.SetColumnSpan(txtPython, 2);
 
-            // Grid
+            layout.Controls.Add(CreateLabel("Office 形式"), 0, 4);
+            var flowOffice = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.LeftToRight,
+                AutoSize = true,
+                WrapContents = false,
+                Margin = new Padding(0, 4, 0, 4),
+            };
+            chkWord = CreateCheckBox("Word (.docx)", true);
+            chkExcel = CreateCheckBox("Excel (.xlsx)", true);
+            chkLegacy = CreateCheckBox("旧形式 (.doc/.xls)", false);
+            flowOffice.Controls.Add(chkWord);
+            flowOffice.Controls.Add(chkExcel);
+            flowOffice.Controls.Add(chkLegacy);
+            layout.Controls.Add(flowOffice, 1, 4);
+            layout.SetColumnSpan(flowOffice, 5);
+
+            layout.Controls.Add(CreateLabel("結果フィルタ"), 0, 5);
+            txtQuickFilter = CreateTextBox();
+            layout.Controls.Add(txtQuickFilter, 1, 5);
+            layout.SetColumnSpan(txtQuickFilter, 5);
+
+            group.Controls.Add(layout);
+            mainLayout.Controls.Add(group, 0, 1);
+
             grid = new DataGridView
             {
                 Dock = DockStyle.Fill,
                 ReadOnly = true,
                 AllowUserToAddRows = false,
                 AllowUserToDeleteRows = false,
+                AllowUserToResizeRows = false,
                 SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = true,
+                AutoGenerateColumns = false,
                 AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
-                AutoGenerateColumns = false
+                BorderStyle = BorderStyle.None,
+                BackgroundColor = Color.White,
+                VirtualMode = true,
+                RowHeadersVisible = false,
+                EnableHeadersVisualStyles = false,
             };
-            grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Path", DataPropertyName = "Path" });
-            grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Entry", DataPropertyName = "Entry" });
-            grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Line", DataPropertyName = "LineNo", Width = 70 });
-            grid.Columns.Add(new DataGridViewTextBoxColumn { HeaderText = "Snippet", DataPropertyName = "Snippet" });
-            grid.DataSource = binding;
 
-            // 右クリックメニュー
+            grid.ColumnHeadersDefaultCellStyle.BackColor = Color.White;
+            grid.ColumnHeadersDefaultCellStyle.ForeColor = Color.FromArgb(0x20, 0x20, 0x20);
+            grid.ColumnHeadersDefaultCellStyle.Font = new Font(Font, FontStyle.Bold);
+            grid.ColumnHeadersHeight = 36;
+            grid.DefaultCellStyle.SelectionBackColor = rowSelected;
+            grid.DefaultCellStyle.SelectionForeColor = Color.Black;
+            grid.RowsDefaultCellStyle.BackColor = rowBack;
+            grid.AlternatingRowsDefaultCellStyle.BackColor = rowAlt;
+            grid.GridColor = Color.FromArgb(0xDD, 0xDD, 0xDD);
+            grid.RowTemplate.Height = 26;
+
+            EnableDoubleBuffer(grid);
+
+            var colPath = new DataGridViewTextBoxColumn { HeaderText = "Path", Name = "colPath", FillWeight = 40f };
+            var colEntry = new DataGridViewTextBoxColumn { HeaderText = "Entry", Name = "colEntry", FillWeight = 20f };
+            var colLine = new DataGridViewTextBoxColumn { HeaderText = "Line", Name = "colLine", FillWeight = 10f };
+            var colSnippet = new DataGridViewTextBoxColumn { HeaderText = "Snippet", Name = "colSnippet", FillWeight = 60f };
+            grid.Columns.AddRange(colPath, colEntry, colLine, colSnippet);
+
+            grid.CellValueNeeded += Grid_CellValueNeeded;
+            grid.CellPainting += Grid_CellPainting;
+            grid.CellMouseEnter += (s, e) => SetHoverRow(e.RowIndex);
+            grid.CellMouseLeave += (s, e) => { if (e.RowIndex >= 0) SetHoverRow(-1); };
+            grid.MouseLeave += (s, e) => SetHoverRow(-1);
+            grid.CellDoubleClick += (s, e) => OpenSelection();
+            grid.ColumnHeaderMouseClick += Grid_ColumnHeaderMouseClick;
+            grid.KeyDown += Grid_KeyDown;
+            grid.CellMouseDown += Grid_CellMouseDown;
+
             var menu = new ContextMenuStrip();
-            menu.Items.Add("フルパスをコピー", null, (s, e) => { var it = Current(); if (it != null) TryClipboard(it.Path); });
-            menu.Items.Add("Entryパスをコピー", null, (s, e) => { var it = Current(); if (it != null) TryClipboard(it.Entry); });
+            menu.Items.Add("パスをコピー", null, (s, e) => CopyToClipboard(r => r.Path));
+            menu.Items.Add("Entry をコピー", null, (s, e) => CopyToClipboard(r => r.Entry));
             menu.Items.Add(new ToolStripSeparator());
-            menu.Items.Add("エクスプローラーで開く", null, (s, e) =>
-            {
-                var it = Current();
-                if (it != null && File.Exists(it.Path)) Process.Start("explorer.exe", "/select,\"" + it.Path + "\"");
-            });
-            menu.Items.Add("親フォルダを開く", null, (s, e) =>
-            {
-                var it = Current();
-                if (it != null) Process.Start("explorer.exe", Path.GetDirectoryName(it.Path));
-            });
+            menu.Items.Add("エクスプローラーで開く", null, (s, e) => OpenSelection());
+            menu.Items.Add("親フォルダを開く", null, (s, e) => OpenParent());
             grid.ContextMenuStrip = menu;
 
-            Controls.Add(grid);
+            mainLayout.Controls.Add(grid, 0, 2);
+
+            var statusPanel = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 4,
+                AutoSize = true,
+                Padding = new Padding(12, 4, 12, 12),
+                BackColor = Color.White,
+            };
+            statusPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+            statusPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+            statusPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+            statusPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 25));
+
+            lblElapsed = CreateStatusLabel("経過: 00:00:00");
+            lblFiles = CreateStatusLabel("処理済み: 0 件");
+            lblHits = CreateStatusLabel("ヒット: 0 件");
+            lblCurrent = CreateStatusLabel("Ready");
+            lblCurrent.AutoEllipsis = true;
+
+            statusPanel.Controls.Add(lblElapsed, 0, 0);
+            statusPanel.Controls.Add(lblFiles, 1, 0);
+            statusPanel.Controls.Add(lblHits, 2, 0);
+            statusPanel.Controls.Add(lblCurrent, 3, 0);
+
+            mainLayout.Controls.Add(statusPanel, 0, 3);
+
+            Controls.Add(mainLayout);
+
+            uiTimer = new Timer { Interval = 500 };
+            uiTimer.Tick += (s, e) => UpdateStatusLabels();
+
+            filterTimer = new Timer { Interval = 350 };
+            filterTimer.Tick += (s, e) =>
+            {
+                filterTimer.Stop();
+                ApplyFilter();
+            };
+
+            txtQuickFilter.TextChanged += (s, e) => filterTimer.Start();
+
+            FormClosing += (s, e) =>
+            {
+                if (searchRunning)
+                {
+                    CancelSearch();
+                    if (currentProc != null)
+                    {
+                        try { currentProc.WaitForExit(2000); } catch { }
+                    }
+                }
+            };
         }
 
-        private SearchRow Current() => grid.CurrentRow?.DataBoundItem as SearchRow;
-        private void TryClipboard(string s) { try { if (!string.IsNullOrEmpty(s)) Clipboard.SetText(s); } catch { } }
-
-        private void Browse()
+        private Button CreateToolbarButton(string text, Color backColor)
         {
-            using (var fbd = new FolderBrowserDialog())
+            var btn = new Button
             {
-                if (Directory.Exists(txtRoot.Text)) fbd.SelectedPath = txtRoot.Text;
-                if (fbd.ShowDialog() == DialogResult.OK) txtRoot.Text = fbd.SelectedPath;
+                Text = text,
+                AutoSize = true,
+                Margin = new Padding(0, 0, 8, 0),
+                Padding = new Padding(16, 6, 16, 6),
+                BackColor = backColor,
+                ForeColor = Color.White,
+                FlatStyle = FlatStyle.Flat,
+                Font = new Font(Font, FontStyle.Bold),
+                TabStop = false,
+            };
+            btn.FlatAppearance.BorderSize = 0;
+            btn.FlatAppearance.MouseOverBackColor = ControlPaint.Light(backColor);
+            btn.FlatAppearance.MouseDownBackColor = ControlPaint.Dark(backColor);
+            return btn;
+        }
+
+        private Button CreateFlatButton(string text)
+        {
+            var btn = new Button
+            {
+                Text = text,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(4),
+                FlatStyle = FlatStyle.Flat,
+                BackColor = Color.FromArgb(0xEE, 0xEE, 0xEE),
+                ForeColor = Color.FromArgb(0x20, 0x20, 0x20),
+            };
+            btn.FlatAppearance.BorderColor = Color.FromArgb(0xCC, 0xCC, 0xCC);
+            btn.FlatAppearance.BorderSize = 1;
+            return btn;
+        }
+
+        private Label CreateLabel(string text)
+        {
+            return new Label
+            {
+                Text = text,
+                TextAlign = ContentAlignment.MiddleLeft,
+                Dock = DockStyle.Fill,
+                Margin = new Padding(3, 4, 3, 4),
+            };
+        }
+
+        private CheckBox CreateCheckBox(string text, bool isChecked)
+        {
+            return new CheckBox
+            {
+                Text = text,
+                Checked = isChecked,
+                AutoSize = true,
+                Margin = new Padding(6, 4, 6, 4),
+                FlatStyle = FlatStyle.Flat,
+            };
+        }
+
+        private TextBox CreateTextBox()
+        {
+            return new TextBox
+            {
+                Dock = DockStyle.Fill,
+                Margin = new Padding(3, 4, 3, 4),
+            };
+        }
+
+        private Label CreateStatusLabel(string text)
+        {
+            return new Label
+            {
+                Text = text,
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleLeft,
+                Margin = new Padding(3, 0, 3, 0),
+            };
+        }
+
+        private void EnableDoubleBuffer(DataGridView dgv)
+        {
+            typeof(DataGridView).InvokeMember("DoubleBuffered", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.SetProperty, null, dgv, new object[] { true });
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == Keys.Enter)
+            {
+                _ = StartSearchAsync();
+                return true;
             }
+            if (keyData == Keys.Escape)
+            {
+                CancelSearch();
+                return true;
+            }
+            if (keyData == Keys.F5)
+            {
+                _ = StartSearchAsync();
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
         }
 
         private async Task StartSearchAsync()
         {
+            if (searchRunning)
+            {
+                return;
+            }
+
             var root = txtRoot.Text.Trim();
             if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
             {
-                MessageBox.Show("起点フォルダが正しくありません"); return;
+                MessageBox.Show("起点フォルダが正しくありません", "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
+
             var query = txtQuery.Text;
             if (string.IsNullOrEmpty(query))
             {
-                if (MessageBox.Show("内容フィルタが空です。全件走査しますか？", "確認", MessageBoxButtons.YesNo) == DialogResult.No)
+                if (MessageBox.Show("内容フィルタが空です。全件走査しますか？", "確認", MessageBoxButtons.YesNo, MessageBoxIcon.Question) != DialogResult.Yes)
+                {
                     return;
+                }
             }
 
-            // Python スクリプトの場所（EXEと同じフォルダ）
+            if (!int.TryParse(string.IsNullOrWhiteSpace(txtPerFile.Text) ? "0" : txtPerFile.Text.Trim(), out var perFile) || perFile < 0)
+            {
+                MessageBox.Show("1ファイル上限には 0 以上の整数を入力してください", "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
             string exeDir = AppDomain.CurrentDomain.BaseDirectory;
             string pyPath = Path.Combine(exeDir, "fastfilefinder_scan.py");
             if (!File.Exists(pyPath))
             {
-                MessageBox.Show("fastfilefinder_scan.py が見つかりません。EXEと同じフォルダに配置してください。");
+                MessageBox.Show("fastfilefinder_scan.py が見つかりません。実行ファイルと同じフォルダに配置してください。", "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
-            // 引数
-            var args = new List<string> { Quote(pyPath), "--folder", Quote(root), "--query", Quote(query) };
+            string pythonExe = string.IsNullOrWhiteSpace(txtPython.Text) ? "python" : txtPython.Text.Trim();
+
+            var args = new List<string>
+            {
+                Quote(pyPath),
+                "--folder",
+                Quote(root),
+                "--query",
+                Quote(query),
+            };
+
             if (chkRegex.Checked) args.Add("--regex");
             if (chkZip.Checked) args.Add("--zip");
             if (chkRecursive.Checked) args.Add("--recursive");
+            if (chkWord.Checked) args.Add("--word");
+            if (chkExcel.Checked) args.Add("--excel");
+            if (chkLegacy.Checked) args.Add("--legacy");
             var exts = txtExts.Text.Trim();
-            if (!string.IsNullOrEmpty(exts)) { args.Add("--exts"); args.Add(Quote(exts)); }
+            if (!string.IsNullOrEmpty(exts))
+            {
+                args.Add("--exts");
+                args.Add(Quote(exts));
+            }
+            if (perFile > 0)
+            {
+                args.Add("--perfile");
+                args.Add(perFile.ToString());
+            }
+            if (numMaxWorkers.Value > 0)
+            {
+                args.Add("--max-workers");
+                args.Add(((int)numMaxWorkers.Value).ToString());
+            }
 
-            string pythonExe = string.IsNullOrWhiteSpace(txtPython.Text) ? "python" : txtPython.Text.Trim();
+            PrepareHighlight(query, chkRegex.Checked);
 
-            // 実行
-            binding.Clear(); lblStatus.Text = "起動中..."; btnSearch.Enabled = false; btnCancel.Enabled = true;
-            cts = new CancellationTokenSource();
+            lock (rowsLock)
+            {
+                allRows.Clear();
+                viewRows.Clear();
+                grid.RowCount = 0;
+            }
+            processedFiles = 0;
+            currentFileDisplay = string.Empty;
+            statusMessage = string.Empty;
+            hoverRow = -1;
+            cancelRequested = false;
+
+            btnSearch.Enabled = false;
+            btnCancel.Enabled = true;
+            searchRunning = true;
+            stopwatch.Reset();
+            stopwatch.Start();
+            uiTimer.Start();
+            UpdateStatusLabels();
+
             currentProc = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = pythonExe,
-                    Arguments = string.Join(" ", args.ToArray()),
+                    Arguments = string.Join(" ", args),
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     CreateNoWindow = true,
                     StandardOutputEncoding = Encoding.UTF8,
-                    StandardErrorEncoding = Encoding.UTF8
+                    StandardErrorEncoding = Encoding.UTF8,
+                    WorkingDirectory = exeDir,
                 },
-                EnableRaisingEvents = true
+                EnableRaisingEvents = true,
             };
             currentProc.StartInfo.EnvironmentVariables["PYTHONIOENCODING"] = "utf-8";
 
-
-            currentProc.OutputDataReceived += (s, ev) =>
-            {
-                if (ev.Data == null) return;
-                if (ev.Data.StartsWith("#")) { BeginInvoke((Action)(() => lblStatus.Text = ev.Data.TrimStart('#'))); return; }
-                AddRowFromTsv(ev.Data);
-            };
-            currentProc.ErrorDataReceived += (s, ev) =>
-            {
-                if (string.IsNullOrEmpty(ev.Data)) return;
-                BeginInvoke((Action)(() => lblStatus.Text = "ERR: " + ev.Data));
-            };
-            currentProc.Exited += (s, ev) =>
-            {
-                BeginInvoke((Action)(() =>
-                {
-                    lblStatus.Text = string.Format("完了。{0:N0} 件", binding.Count);
-                    btnSearch.Enabled = true; btnCancel.Enabled = false;
-                }));
-            };
+            currentProc.OutputDataReceived += CurrentProc_OutputDataReceived;
+            currentProc.ErrorDataReceived += CurrentProc_ErrorDataReceived;
+            currentProc.Exited += (s, e) => BeginInvoke((Action)SearchCompleted);
 
             try
             {
                 currentProc.Start();
                 currentProc.BeginOutputReadLine();
                 currentProc.BeginErrorReadLine();
-                await Task.Run(() =>
-                {
-                    while (!currentProc.HasExited)
-                    {
-                        if (cts.IsCancellationRequested) { try { currentProc.Kill(); } catch { } break; }
-                        Thread.Sleep(100);
-                    }
-                });
             }
             catch (Exception ex)
             {
-                MessageBox.Show("python 実行エラー: " + ex.Message);
-                btnSearch.Enabled = true; btnCancel.Enabled = false; lblStatus.Text = "エラー";
+                searchRunning = false;
+                btnSearch.Enabled = true;
+                btnCancel.Enabled = false;
+                uiTimer.Stop();
+                stopwatch.Reset();
+                MessageBox.Show("python 実行エラー: " + ex.Message, "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            await Task.CompletedTask;
+        }
+
+        private void CurrentProc_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.Data))
+            {
+                return;
+            }
+
+            if (e.Data.StartsWith("#"))
+            {
+                BeginInvoke((Action)(() => HandleStatusLine(e.Data.Substring(1))));
+                return;
+            }
+
+            var parts = e.Data.Split(new[] { '\t' }, 4);
+            if (parts.Length < 4)
+            {
+                return;
+            }
+
+            int.TryParse(parts[2], out var lineNo);
+            var row = new SearchRow
+            {
+                Path = parts[0],
+                Entry = parts[1],
+                LineNo = lineNo,
+                Snippet = parts[3],
+            };
+            BeginInvoke((Action)(() => AddRow(row)));
+        }
+
+        private void CurrentProc_ErrorDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (string.IsNullOrEmpty(e.Data))
+            {
+                return;
+            }
+
+            BeginInvoke((Action)(() =>
+            {
+                statusMessage = "⚠ " + e.Data;
+                statusMessageExpire = DateTime.Now.AddSeconds(10);
+                UpdateStatusLabels();
+            }));
+        }
+
+        private void HandleStatusLine(string line)
+        {
+            var parts = line.Split('\t');
+            if (parts.Length == 0)
+            {
+                return;
+            }
+
+            switch (parts[0])
+            {
+                case "queued":
+                    statusMessage = $"対象 {parts.ElementAtOrDefault(1) ?? "0"} ファイル";
+                    statusMessageExpire = DateTime.Now.AddSeconds(10);
+                    break;
+                case "current":
+                    currentFileDisplay = parts.ElementAtOrDefault(1) ?? string.Empty;
+                    break;
+                case "progress":
+                    if (parts.Length > 1 && int.TryParse(parts[1], out var files))
+                    {
+                        processedFiles = files;
+                    }
+                    if (parts.Length > 2 && int.TryParse(parts[2], out var hits))
+                    {
+                        if (hits > allRows.Count)
+                        {
+                            lblHits.Text = $"ヒット: {hits:N0} 件 (表示: {viewRows.Count:N0})";
+                        }
+                    }
+                    if (parts.Length > 3)
+                    {
+                        currentFileDisplay = parts[3];
+                    }
+                    break;
+                case "done":
+                    if (parts.Length > 1 && int.TryParse(parts[1], out var doneFiles))
+                    {
+                        processedFiles = doneFiles;
+                    }
+                    if (parts.Length > 2 && int.TryParse(parts[2], out var doneHits))
+                    {
+                        statusMessage = $"完了: {doneHits:N0} 件";
+                        statusMessageExpire = DateTime.Now.AddSeconds(30);
+                    }
+                    break;
+                default:
+                    statusMessage = parts[0];
+                    statusMessageExpire = DateTime.Now.AddSeconds(10);
+                    break;
+            }
+
+            UpdateStatusLabels();
+        }
+
+        private void AddRow(SearchRow row)
+        {
+            lock (rowsLock)
+            {
+                allRows.Add(row);
+                if (IsVisibleByFilter(row))
+                {
+                    viewRows.Add(row);
+                    grid.RowCount = viewRows.Count;
+                    grid.InvalidateRow(viewRows.Count - 1);
+                }
+            }
+            UpdateStatusLabels();
+        }
+
+        private bool IsVisibleByFilter(SearchRow row)
+        {
+            if (string.IsNullOrEmpty(filterText))
+            {
+                return true;
+            }
+
+            return (row.Path?.IndexOf(filterText, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0
+                || (row.Entry?.IndexOf(filterText, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0
+                || (row.Snippet?.IndexOf(filterText, StringComparison.OrdinalIgnoreCase) ?? -1) >= 0;
+        }
+
+        private void ApplyFilter()
+        {
+            filterText = txtQuickFilter.Text.Trim();
+            lock (rowsLock)
+            {
+                viewRows.Clear();
+                foreach (var row in allRows)
+                {
+                    if (IsVisibleByFilter(row))
+                    {
+                        viewRows.Add(row);
+                    }
+                }
+                grid.RowCount = viewRows.Count;
+            }
+            UpdateStatusLabels();
+            grid.Invalidate();
+        }
+
+        private void PrepareHighlight(string query, bool isRegex)
+        {
+            highlightIsRegex = isRegex;
+            highlightRegex = null;
+            highlightText = string.Empty;
+            if (isRegex)
+            {
+                try
+                {
+                    highlightRegex = new Regex(query, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+                }
+                catch
+                {
+                    highlightRegex = null;
+                }
+            }
+            else
+            {
+                highlightText = query ?? string.Empty;
             }
         }
 
-        private void CancelSearch() { try { cts?.Cancel(); } catch { } }
-
-        private void AddRowFromTsv(string line)
+        private void CancelSearch()
         {
-            // TSV: path\tentry\tlineno\tsnippet
-            var cols = line.Split(new[] { '\t' }, 4);
-            if (cols.Length < 4) return;
-            int lineno = 0; int.TryParse(cols[2], out lineno);
-            var row = new SearchRow { Path = cols[0], Entry = cols[1], LineNo = lineno, Snippet = cols[3] };
-            BeginInvoke((Action)(() => binding.Add(row)));
+            if (!searchRunning)
+            {
+                return;
+            }
+
+            cancelRequested = true;
+            try
+            {
+                if (currentProc != null && !currentProc.HasExited)
+                {
+                    currentProc.Kill();
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void SearchCompleted()
+        {
+            uiTimer.Stop();
+            stopwatch.Stop();
+            searchRunning = false;
+            btnSearch.Enabled = true;
+            btnCancel.Enabled = false;
+            UpdateStatusLabels();
+            if (currentProc != null)
+            {
+                currentProc.OutputDataReceived -= CurrentProc_OutputDataReceived;
+                currentProc.ErrorDataReceived -= CurrentProc_ErrorDataReceived;
+                try { currentProc.Dispose(); } catch { }
+                currentProc = null;
+            }
+            if (cancelRequested)
+            {
+                statusMessage = "中断しました";
+                statusMessageExpire = DateTime.Now.AddSeconds(10);
+            }
+            else
+            {
+                statusMessage = "完了";
+                statusMessageExpire = DateTime.Now.AddSeconds(10);
+            }
+            UpdateStatusLabels();
+        }
+
+        private void UpdateStatusLabels()
+        {
+            var elapsed = stopwatch.Elapsed;
+            lblElapsed.Text = "経過: " + elapsed.ToString("hh\\:mm\\:ss");
+            lblFiles.Text = $"処理済み: {processedFiles:N0} 件";
+            lblHits.Text = $"ヒット: {allRows.Count:N0} 件 (表示: {viewRows.Count:N0})";
+
+            string display = string.Empty;
+            if (!string.IsNullOrEmpty(currentFileDisplay))
+            {
+                display = TruncatePath(currentFileDisplay, 80);
+            }
+
+            if (!string.IsNullOrEmpty(statusMessage) && statusMessageExpire > DateTime.Now)
+            {
+                if (string.IsNullOrEmpty(display))
+                {
+                    display = statusMessage;
+                }
+                else
+                {
+                    display += " | " + statusMessage;
+                }
+            }
+            else if (statusMessageExpire <= DateTime.Now)
+            {
+                statusMessage = string.Empty;
+            }
+
+            lblCurrent.Text = string.IsNullOrEmpty(display) ? (searchRunning ? "処理中..." : "Ready") : display;
+        }
+
+        private string TruncatePath(string value, int max)
+        {
+            if (string.IsNullOrEmpty(value) || value.Length <= max)
+            {
+                return value;
+            }
+            int keep = max - 3;
+            if (keep <= 0)
+            {
+                return value.Substring(0, max);
+            }
+            int head = keep / 2;
+            int tail = keep - head;
+            return value.Substring(0, head) + "..." + value.Substring(value.Length - tail);
+        }
+
+        private void Grid_CellValueNeeded(object sender, DataGridViewCellValueEventArgs e)
+        {
+            if (e.RowIndex < 0)
+            {
+                return;
+            }
+            SearchRow row;
+            lock (rowsLock)
+            {
+                if (e.RowIndex >= viewRows.Count)
+                {
+                    return;
+                }
+                row = viewRows[e.RowIndex];
+            }
+
+            switch (grid.Columns[e.ColumnIndex].Name)
+            {
+                case "colPath":
+                    e.Value = row.Path;
+                    break;
+                case "colEntry":
+                    e.Value = row.Entry;
+                    break;
+                case "colLine":
+                    e.Value = row.LineNo;
+                    break;
+                case "colSnippet":
+                    e.Value = row.Snippet;
+                    break;
+            }
+        }
+
+        private void Grid_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
+        {
+            if (e.RowIndex < 0)
+            {
+                e.CellStyle.BackColor = Color.White;
+                e.CellStyle.ForeColor = Color.FromArgb(0x20, 0x20, 0x20);
+                return;
+            }
+
+            var selected = (e.State & DataGridViewElementStates.Selected) != 0;
+            var hover = !selected && e.RowIndex == hoverRow;
+            var background = selected ? rowSelected : hover ? rowHover : (e.RowIndex % 2 == 0 ? rowBack : rowAlt);
+
+            using (var brush = new SolidBrush(background))
+            {
+                e.Graphics.FillRectangle(brush, e.CellBounds);
+            }
+
+            e.Paint(e.ClipBounds, DataGridViewPaintParts.Border);
+
+            if (grid.Columns[e.ColumnIndex].Name != "colSnippet")
+            {
+                e.PaintContent(e.CellBounds);
+                e.Handled = true;
+                return;
+            }
+
+            var text = Convert.ToString(e.FormattedValue) ?? string.Empty;
+            DrawHighlightedText(e.Graphics, text, e.CellBounds, e.CellStyle.Font, e.CellStyle.ForeColor);
+            e.Handled = true;
+        }
+
+        private void DrawHighlightedText(Graphics g, string text, Rectangle bounds, Font font, Color color)
+        {
+            var rect = new Rectangle(bounds.X + 4, bounds.Y + 4, bounds.Width - 8, bounds.Height - 8);
+            int x = rect.Left;
+            int right = rect.Right;
+            var flags = TextFormatFlags.Left | TextFormatFlags.NoPrefix | TextFormatFlags.NoPadding | TextFormatFlags.VerticalCenter | TextFormatFlags.PreserveGraphicsClipping;
+
+            if (string.IsNullOrEmpty(text) || (highlightIsRegex && (highlightRegex == null || !highlightRegex.IsMatch(text))) || (!highlightIsRegex && string.IsNullOrEmpty(highlightText)))
+            {
+                TextRenderer.DrawText(g, text, font, rect, color, flags | TextFormatFlags.EndEllipsis);
+                return;
+            }
+
+            if (highlightIsRegex)
+            {
+                var match = highlightRegex?.Match(text);
+                if (match == null || !match.Success)
+                {
+                    TextRenderer.DrawText(g, text, font, rect, color, flags | TextFormatFlags.EndEllipsis);
+                    return;
+                }
+                DrawSegment(g, text.Substring(0, match.Index), font, color, rect, ref x, right, flags);
+                DrawSegment(g, match.Value, font, Color.Black, rect, ref x, right, flags, true);
+                DrawSegment(g, text.Substring(match.Index + match.Length), font, color, rect, ref x, right, flags);
+                return;
+            }
+
+            int pos = 0;
+            var search = highlightText;
+            while (pos < text.Length)
+            {
+                int idx = text.IndexOf(search, pos, StringComparison.OrdinalIgnoreCase);
+                if (idx < 0)
+                {
+                    DrawSegment(g, text.Substring(pos), font, color, rect, ref x, right, flags);
+                    break;
+                }
+                if (idx > pos)
+                {
+                    DrawSegment(g, text.Substring(pos, idx - pos), font, color, rect, ref x, right, flags);
+                }
+                DrawSegment(g, text.Substring(idx, search.Length), font, Color.Black, rect, ref x, right, flags, true);
+                pos = idx + search.Length;
+                if (x >= right)
+                {
+                    break;
+                }
+            }
+        }
+
+        private void DrawSegment(Graphics g, string text, Font font, Color color, Rectangle rect, ref int x, int right, TextFormatFlags flags, bool highlight = false)
+        {
+            if (string.IsNullOrEmpty(text) || x >= right)
+            {
+                return;
+            }
+            var size = TextRenderer.MeasureText(g, text, font, new Size(int.MaxValue, rect.Height), flags);
+            int width = Math.Min(size.Width, right - x);
+            var segmentRect = new Rectangle(x, rect.Top, width, rect.Height);
+            if (highlight)
+            {
+                using (var b = new SolidBrush(highlightBack))
+                {
+                    g.FillRectangle(b, segmentRect);
+                }
+            }
+            TextRenderer.DrawText(g, text, font, segmentRect, color, flags);
+            x += width;
+        }
+
+        private void SetHoverRow(int rowIndex)
+        {
+            if (hoverRow == rowIndex)
+            {
+                return;
+            }
+            int previous = hoverRow;
+            hoverRow = rowIndex;
+            if (previous >= 0 && previous < grid.RowCount)
+            {
+                grid.InvalidateRow(previous);
+            }
+            if (hoverRow >= 0 && hoverRow < grid.RowCount)
+            {
+                grid.InvalidateRow(hoverRow);
+            }
+        }
+
+        private void Grid_ColumnHeaderMouseClick(object sender, DataGridViewCellMouseEventArgs e)
+        {
+            var column = grid.Columns[e.ColumnIndex];
+            Sort(column.Name, Control.ModifierKeys.HasFlag(Keys.Shift));
+        }
+
+        private void Sort(string columnName, bool descending)
+        {
+            lock (rowsLock)
+            {
+                Comparison<SearchRow> comparison = null;
+                switch (columnName)
+                {
+                    case "colPath":
+                        comparison = (a, b) => string.Compare(a.Path, b.Path, StringComparison.OrdinalIgnoreCase);
+                        break;
+                    case "colEntry":
+                        comparison = (a, b) => string.Compare(a.Entry, b.Entry, StringComparison.OrdinalIgnoreCase);
+                        break;
+                    case "colLine":
+                        comparison = (a, b) => a.LineNo.CompareTo(b.LineNo);
+                        break;
+                    case "colSnippet":
+                        comparison = (a, b) => string.Compare(a.Snippet, b.Snippet, StringComparison.OrdinalIgnoreCase);
+                        break;
+                }
+
+                if (comparison == null)
+                {
+                    return;
+                }
+
+                viewRows.Sort((a, b) => descending ? -comparison(a, b) : comparison(a, b));
+            }
+            grid.Invalidate();
+        }
+
+        private void Grid_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Control && e.KeyCode == Keys.C)
+            {
+                CopyRows();
+                e.Handled = true;
+            }
+        }
+
+        private void CopyRows()
+        {
+            if (grid.SelectedRows.Count == 0)
+            {
+                return;
+            }
+
+            var sb = new StringBuilder();
+            foreach (DataGridViewRow row in grid.SelectedRows)
+            {
+                var data = GetRow(row.Index);
+                if (data == null)
+                {
+                    continue;
+                }
+                sb.AppendLine(string.Join("\t", data.Path, data.Entry, data.LineNo.ToString(), data.Snippet));
+            }
+            if (sb.Length > 0)
+            {
+                try
+                {
+                    Clipboard.SetText(sb.ToString());
+                    statusMessage = "クリップボードにコピーしました";
+                    statusMessageExpire = DateTime.Now.AddSeconds(5);
+                    UpdateStatusLabels();
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        private void CopyToClipboard(Func<SearchRow, string> selector)
+        {
+            var row = GetRow(grid.CurrentRow?.Index ?? -1);
+            if (row == null)
+            {
+                return;
+            }
+            var value = selector(row);
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+            try
+            {
+                Clipboard.SetText(value);
+                statusMessage = "コピーしました";
+                statusMessageExpire = DateTime.Now.AddSeconds(5);
+                UpdateStatusLabels();
+            }
+            catch
+            {
+            }
+        }
+
+        private void Grid_CellMouseDown(object sender, DataGridViewCellMouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right && e.RowIndex >= 0)
+            {
+                grid.ClearSelection();
+                grid.Rows[e.RowIndex].Selected = true;
+                grid.CurrentCell = grid.Rows[e.RowIndex].Cells[e.ColumnIndex >= 0 ? e.ColumnIndex : 0];
+            }
+        }
+
+        private SearchRow GetRow(int index)
+        {
+            if (index < 0)
+            {
+                return null;
+            }
+            lock (rowsLock)
+            {
+                if (index >= viewRows.Count)
+                {
+                    return null;
+                }
+                return viewRows[index];
+            }
+        }
+
+        private void OpenSelection()
+        {
+            var row = GetRow(grid.CurrentRow?.Index ?? -1);
+            if (row == null)
+            {
+                return;
+            }
+            try
+            {
+                if (!string.IsNullOrEmpty(row.Path) && File.Exists(row.Path))
+                {
+                    Process.Start("explorer.exe", $"/select,\"{row.Path}\"");
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void OpenParent()
+        {
+            var row = GetRow(grid.CurrentRow?.Index ?? -1);
+            if (row == null)
+            {
+                return;
+            }
+            try
+            {
+                var dir = Path.GetDirectoryName(row.Path);
+                if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+                {
+                    Process.Start(dir);
+                }
+            }
+            catch
+            {
+            }
         }
 
         private void ExportCsv()
         {
-            if (binding.Count == 0) { MessageBox.Show("出力する行がありません"); return; }
-            using (var sfd = new SaveFileDialog { Filter = "CSV (*.csv)|*.csv|All Files (*.*)|*.*", FileName = "FastFileFinder.csv" })
+            List<SearchRow> rows;
+            lock (rowsLock)
             {
-                if (sfd.ShowDialog() != DialogResult.OK) return;
+                rows = new List<SearchRow>(viewRows);
+            }
+
+            if (rows.Count == 0)
+            {
+                MessageBox.Show("出力する行がありません", "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            using (var sfd = new SaveFileDialog
+            {
+                Filter = "CSV (*.csv)|*.csv|TSV (*.tsv)|*.tsv|All Files (*.*)|*.*",
+                FileName = "FastFileFinder.csv",
+            })
+            {
+                if (sfd.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
                 try
                 {
+                    var isTsv = string.Equals(Path.GetExtension(sfd.FileName), ".tsv", StringComparison.OrdinalIgnoreCase);
                     using (var sw = new StreamWriter(sfd.FileName, false, new UTF8Encoding(true)))
                     {
-                        sw.WriteLine("Path,Entry,Line,Snippet");
-                        foreach (var r in binding)
+                        if (isTsv)
                         {
-                            sw.WriteLine(string.Join(",", Csv(r.Path), Csv(r.Entry), r.LineNo.ToString(), Csv(r.Snippet)));
+                            foreach (var r in rows)
+                            {
+                                sw.WriteLine(string.Join("\t", r.Path, r.Entry, r.LineNo.ToString(), r.Snippet));
+                            }
+                        }
+                        else
+                        {
+                            sw.WriteLine("Path,Entry,Line,Snippet");
+                            foreach (var r in rows)
+                            {
+                                sw.WriteLine(string.Join(",", Csv(r.Path), Csv(r.Entry), r.LineNo.ToString(), Csv(r.Snippet)));
+                            }
                         }
                     }
-                    lblStatus.Text = "CSVに出力しました: " + sfd.FileName;
+                    statusMessage = "CSV/TSV を出力しました";
+                    statusMessageExpire = DateTime.Now.AddSeconds(10);
+                    UpdateStatusLabels();
                 }
-                catch (Exception ex) { MessageBox.Show("CSV出力に失敗: " + ex.Message); }
+                catch (Exception ex)
+                {
+                    MessageBox.Show("CSV 出力に失敗しました: " + ex.Message, "FastFileFinder", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
             }
         }
-        private string Csv(string s) { if (string.IsNullOrEmpty(s)) return ""; return "\"" + s.Replace("\"", "\"\"") + "\""; }
+
+        private string Csv(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+            {
+                return string.Empty;
+            }
+            return "\"" + s.Replace("\"", "\"\"") + "\"";
+        }
+
+        private void Browse()
+        {
+            using (var dialog = new FolderBrowserDialog())
+            {
+                if (Directory.Exists(txtRoot.Text))
+                {
+                    dialog.SelectedPath = txtRoot.Text;
+                }
+                if (dialog.ShowDialog() == DialogResult.OK)
+                {
+                    txtRoot.Text = dialog.SelectedPath;
+                }
+            }
+        }
 
         private static string Quote(string s)
         {
-            if (string.IsNullOrEmpty(s)) return "\"\"";
-            if (s.IndexOf('\"') >= 0) s = s.Replace("\"", "\\\"");
-            if (s.IndexOf(' ') >= 0 || s.IndexOf('\\') >= 0 || s.IndexOf(';') >= 0) return "\"" + s + "\"";
+            if (string.IsNullOrEmpty(s))
+            {
+                return "\"\"";
+            }
+            if (s.IndexOf('"') >= 0)
+            {
+                s = s.Replace("\"", "\\\"");
+            }
+            if (s.IndexOf(' ') >= 0 || s.IndexOf('\t') >= 0 || s.IndexOf(';') >= 0)
+            {
+                return "\"" + s + "\"";
+            }
             return s;
         }
     }

--- a/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
+++ b/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
@@ -1,34 +1,80 @@
-# fastfilefinder_scan.py - text/regex scanner with optional ZIP support (UTF-8 stdout)
-# Usage:
-#   python fastfilefinder_scan.py --folder <dir> --query <q>
-#     [--regex] [--zip] [--recursive] [--exts "txt;log;cs"] [--perfile 0]
-#
-# NOTE:
-#   * 既定で「1ファイル内の全ヒット行」を出力します。
-#   * 多すぎる場合は --perfile で 1ファイルあたりの上限件数を指定できます（0=無制限）。
+# fastfilefinder_scan.py - fast content scanner with optional Office document support
+# Outputs UTF-8 TSV lines: path \t entry \t lineno \t snippet
 
-import argparse, os, sys, re
-from zipfile import ZipFile, BadZipFile
+import argparse
+import os
+import re
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import TextIOWrapper
+from zipfile import BadZipFile, ZipFile
 
-# よくある文字コード（順に試す）
+# Optional dependencies
+try:  # python-docx for .docx
+    from docx import Document  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    Document = None  # type: ignore
+
+try:  # openpyxl for .xlsx
+    import openpyxl  # type: ignore
+    from openpyxl.utils.cell import get_column_letter  # type: ignore
+except Exception:  # pragma: no cover - dependency may be missing
+    openpyxl = None  # type: ignore
+    get_column_letter = None  # type: ignore
+
+try:  # legacy Office via COM
+    import pythoncom  # type: ignore
+    import win32com.client  # type: ignore
+except Exception:  # pragma: no cover - optional
+    pythoncom = None  # type: ignore
+    win32com = None  # type: ignore
+
+
+# Common encodings to try for text files
 ENCODINGS = (
-    "utf-8-sig",     # BOM付きUTF-8
-    "utf-16-le", "utf-16-be",  # UTF-16
-    "cp932",         # Shift-JIS (Windows-31J)
-    "utf-8",         # BOMなしUTF-8
+    "utf-8-sig",
+    "utf-16-le",
+    "utf-16-be",
+    "cp932",
+    "utf-8",
 )
 
-# 標準出力は常にUTF-8
+# Ensure stdout is UTF-8
 try:
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 except Exception:
     pass
 
-CACHE = {"rx": {}}
+stdout_lock = threading.Lock()
+warned = set()
 
-def iter_paths(folder, recursive):
+
+def emit_tsv(path: str, entry: str, lineno: int, line: str) -> None:
+    line = line.replace("\t", " ").rstrip("\r\n")
+    with stdout_lock:
+        sys.stdout.write(f"{path}\t{entry}\t{lineno}\t{line}\n")
+        sys.stdout.flush()
+
+
+def emit_status(tag: str, *parts: object) -> None:
+    payload = "\t".join(str(p) for p in parts)
+    with stdout_lock:
+        sys.stdout.write(f"#{tag}\t{payload}\n")
+        sys.stdout.flush()
+
+
+def warn_once(kind: str, message: str) -> None:
+    if kind in warned:
+        return
+    warned.add(kind)
+    sys.stderr.write(message + "\n")
+    sys.stderr.flush()
+
+
+def iter_paths(folder: str, recursive: bool):
     if recursive:
         for root, _, files in os.walk(folder):
             for name in files:
@@ -42,64 +88,74 @@ def iter_paths(folder, recursive):
         except Exception:
             return
 
-def should_target(path, exts):
+
+def normalize_ext(ext: str) -> str:
+    return ext.lower().lstrip(".")
+
+
+def should_target(path: str, exts: set) -> bool:
     if not exts:
         return True
-    _, ext = os.path.splitext(path)
-    return ext.lower().lstrip(".") in exts
+    return normalize_ext(os.path.splitext(path)[1]) in exts
 
-def match_line(line, pattern, is_regex):
-    if is_regex:
-        rx = CACHE["rx"].get(pattern)
-        if rx is None:
-            rx = re.compile(pattern, re.IGNORECASE)
-            CACHE["rx"][pattern] = rx
-        return rx.search(line) is not None
-    return pattern.lower() in line.lower()
 
-def out(path, entry, lineno, line):
-    line = line.replace("\t", " ").rstrip("\r\n")
-    sys.stdout.write(f"{path}\t{entry}\t{lineno}\t{line}\n")
-    sys.stdout.flush()
+def build_matcher(pattern: str, use_regex: bool):
+    if use_regex:
+        rx = re.compile(pattern, re.IGNORECASE)
 
-def scan_regular_file(path, pattern, is_regex, exts, perfile):
+        def matcher(line: str):
+            return rx.search(line)
+
+        return matcher
+
+    lowered = pattern.lower()
+
+    def matcher(line: str):
+        return lowered in line.lower()
+
+    return matcher
+
+
+def scan_text_file(path: str, matcher, exts: set, perfile: int) -> int:
     if not should_target(path, exts):
-        return
+        return 0
     hits = 0
     for enc in ENCODINGS:
         try:
-            with open(path, "r", encoding=enc, errors="replace") as r:
-                for i, line in enumerate(r, 1):
-                    if match_line(line, pattern, is_regex):
-                        out(path, "", i, line)
+            with open(path, "r", encoding=enc, errors="replace") as reader:
+                for lineno, line in enumerate(reader, 1):
+                    if matcher(line):
+                        emit_tsv(path, "", lineno, line)
                         hits += 1
                         if perfile and hits >= perfile:
-                            return
+                            return hits
             break
         except UnicodeDecodeError:
             continue
         except (OSError, IOError):
-            return
+            return hits
+    return hits
 
-def scan_zip(path, pattern, is_regex, exts, perfile):
+
+def scan_zip(path: str, matcher, exts: set, perfile: int) -> int:
+    hits = 0
     try:
         with ZipFile(path) as zf:
             for name in zf.namelist():
-                # エントリごとの件数カウント
-                entry_hits = 0
-                _, ext = os.path.splitext(name)
-                if exts and ext.lower().lstrip(".") not in exts:
+                if exts and normalize_ext(os.path.splitext(name)[1]) not in exts:
                     continue
+                entry_hits = 0
                 try:
                     for enc in ENCODINGS:
                         try:
-                            with zf.open(name, "r") as f, TextIOWrapper(
-                                f, encoding=enc, errors="replace"
-                            ) as r:
-                                for i, line in enumerate(r, 1):
-                                    if match_line(line, pattern, is_regex):
-                                        out(path, name, i, line)
+                            with zf.open(name, "r") as raw, TextIOWrapper(
+                                raw, encoding=enc, errors="replace"
+                            ) as reader:
+                                for lineno, line in enumerate(reader, 1):
+                                    if matcher(line):
+                                        emit_tsv(path, name, lineno, line)
                                         entry_hits += 1
+                                        hits += 1
                                         if perfile and entry_hits >= perfile:
                                             break
                             break
@@ -108,35 +164,262 @@ def scan_zip(path, pattern, is_regex, exts, perfile):
                 except KeyError:
                     continue
     except BadZipFile:
-        return
+        pass
+    except Exception as exc:
+        warn_once(f"zip:{path}", f"ZIP 読み取り失敗: {path} ({exc})")
+    return hits
 
-def scan_file(path, pattern, is_regex, zip_ok, exts, perfile):
-    if path.lower().endswith(".zip"):
-        if zip_ok:
-            scan_zip(path, pattern, is_regex, exts, perfile)
-    else:
-        scan_regular_file(path, pattern, is_regex, exts, perfile)
 
-def main():
+def iter_docx_lines(doc):
+    line_no = 0
+    for idx, para in enumerate(doc.paragraphs, 1):
+        text = para.text.strip()
+        line_no += 1
+        yield line_no, f"paragraph:{idx}", text
+    for t_idx, table in enumerate(doc.tables, 1):
+        for r_idx, row in enumerate(table.rows, 1):
+            cells = [cell.text.strip() for cell in row.cells]
+            text = "\t".join(cells).strip()
+            line_no += 1
+            yield line_no, f"table{t_idx}:row{r_idx}", text
+
+
+def scan_docx(path: str, matcher, perfile: int) -> int:
+    if Document is None:
+        warn_once("docx", "python-docx がインストールされていないため .docx をスキップします")
+        return 0
+    hits = 0
+    try:
+        doc = Document(path)
+    except Exception as exc:
+        warn_once(f"docx:{path}", f".docx 読み込み失敗: {path} ({exc})")
+        return 0
+    for lineno, entry, text in iter_docx_lines(doc):
+        if not text:
+            continue
+        if matcher(text):
+            emit_tsv(path, entry, lineno, text)
+            hits += 1
+            if perfile and hits >= perfile:
+                break
+    return hits
+
+
+def iter_xlsx_cells(workbook):
+    for sheet in workbook.worksheets:
+        title = sheet.title
+        for row_idx, row in enumerate(sheet.iter_rows(values_only=True), 1):
+            for col_idx, value in enumerate(row, 1):
+                if value is None:
+                    continue
+                text = str(value).strip()
+                if not text:
+                    continue
+                addr = f"{title}!{get_column_letter(col_idx)}{row_idx}" if get_column_letter else f"{title}!{col_idx},{row_idx}"
+                yield row_idx, addr, text
+
+
+def scan_xlsx(path: str, matcher, perfile: int) -> int:
+    if openpyxl is None:
+        warn_once("xlsx", "openpyxl がインストールされていないため .xlsx をスキップします")
+        return 0
+    hits = 0
+    try:
+        wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    except Exception as exc:
+        warn_once(f"xlsx:{path}", f".xlsx 読み込み失敗: {path} ({exc})")
+        return 0
+    try:
+        for lineno, entry, text in iter_xlsx_cells(wb):
+            if matcher(text):
+                emit_tsv(path, entry, lineno, text)
+                hits += 1
+                if perfile and hits >= perfile:
+                    break
+    finally:
+        try:
+            wb.close()
+        except Exception:
+            pass
+    return hits
+
+
+def scan_doc_legacy(path: str, matcher, perfile: int) -> int:
+    if win32com is None or pythoncom is None:
+        warn_once("doc", "pywin32 がないため .doc をスキップします")
+        return 0
+    hits = 0
+    pythoncom.CoInitialize()
+    try:
+        try:
+            word = win32com.client.Dispatch("Word.Application")
+        except Exception as exc:
+            warn_once("doc-open", f"Word COM を初期化できません (.doc スキップ): {exc}")
+            return 0
+        word.Visible = False
+        try:
+            doc = word.Documents.Open(
+                path,
+                ConfirmConversions=False,
+                ReadOnly=True,
+                AddToRecentFiles=False,
+            )
+        except Exception as exc:
+            warn_once(f"doc:{path}", f".doc 読み込み失敗: {path} ({exc})")
+            word.Quit()
+            return 0
+        try:
+            text = doc.Range().Text
+        finally:
+            doc.Close(False)
+            word.Quit()
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if matcher(line):
+                emit_tsv(path, "doc", lineno, line)
+                hits += 1
+                if perfile and hits >= perfile:
+                    break
+    finally:
+        pythoncom.CoUninitialize()
+    return hits
+
+
+def scan_xls_legacy(path: str, matcher, perfile: int) -> int:
+    if win32com is None or pythoncom is None:
+        warn_once("xls", "pywin32 がないため .xls をスキップします")
+        return 0
+    hits = 0
+    pythoncom.CoInitialize()
+    try:
+        try:
+            excel = win32com.client.Dispatch("Excel.Application")
+        except Exception as exc:
+            warn_once("xls-open", f"Excel COM を初期化できません (.xls スキップ): {exc}")
+            return 0
+        excel.Visible = False
+        excel.DisplayAlerts = False
+        try:
+            wb = excel.Workbooks.Open(path, ReadOnly=True)
+        except Exception as exc:
+            warn_once(f"xls:{path}", f".xls 読み込み失敗: {path} ({exc})")
+            excel.Quit()
+            return 0
+        try:
+            for sheet in wb.Worksheets:
+                try:
+                    used = sheet.UsedRange
+                    values = used.Value
+                except Exception:
+                    continue
+                rows = values
+                if rows is None:
+                    continue
+                if not isinstance(rows, (list, tuple)):
+                    rows = [[rows]]
+                for row_idx, row in enumerate(rows, 1):
+                    if not isinstance(row, (list, tuple)):
+                        row = [row]
+                    for col_idx, value in enumerate(row, 1):
+                        if value in (None, ""):
+                            continue
+                        text = str(value).strip()
+                        if not text:
+                            continue
+                        entry = f"{sheet.Name}!{col_idx},{row_idx}"
+                        if matcher(text):
+                            emit_tsv(path, entry, row_idx, text)
+                            hits += 1
+                            if perfile and hits >= perfile:
+                                excel.Quit()
+                                return hits
+        finally:
+            wb.Close(False)
+            excel.Quit()
+    finally:
+        pythoncom.CoUninitialize()
+    return hits
+
+
+def scan_file(path: str, matcher, args, exts: set) -> int:
+    ext = normalize_ext(os.path.splitext(path)[1])
+    perfile = args.perfile
+    if ext == "zip":
+        if args.zip:
+            return scan_zip(path, matcher, exts, perfile)
+        return 0
+    if not should_target(path, exts):
+        return 0
+    if ext == "docx" and args.word:
+        return scan_docx(path, matcher, perfile)
+    if ext == "xlsx" and args.excel:
+        return scan_xlsx(path, matcher, perfile)
+    if ext == "doc" and args.legacy and args.word:
+        return scan_doc_legacy(path, matcher, perfile)
+    if ext == "xls" and args.legacy and args.excel:
+        return scan_xls_legacy(path, matcher, perfile)
+    return scan_text_file(path, matcher, exts, perfile)
+
+
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--folder", required=True)
     ap.add_argument("--query", required=True)
     ap.add_argument("--regex", action="store_true")
     ap.add_argument("--zip", action="store_true")
     ap.add_argument("--recursive", action="store_true")
-    ap.add_argument("--exts", default="")      # "txt;log;cs" or "txt,log"
-    ap.add_argument("--perfile", type=int, default=0, help="1ファイルあたりの最大ヒット数 (0=無制限)")
+    ap.add_argument("--exts", default="")
+    ap.add_argument("--perfile", type=int, default=0)
+    ap.add_argument("--word", action="store_true")
+    ap.add_argument("--excel", action="store_true")
+    ap.add_argument("--legacy", action="store_true")
+    ap.add_argument("--max-workers", type=int, default=0)
     args = ap.parse_args()
 
-    exts = set(
+    ext_filter = set(
         e.strip().lower()
         for e in args.exts.replace(",", ";").split(";")
         if e.strip()
     )
 
-    print("#scanning...", end="")
-    for p in iter_paths(args.folder, args.recursive):
-        scan_file(p, args.query, args.regex, args.zip, exts, args.perfile)
+    try:
+        matcher = build_matcher(args.query, args.regex)
+    except re.error as exc:
+        sys.stderr.write(f"正規表現エラー: {exc}\n")
+        sys.stderr.flush()
+        return
+
+    files = list(iter_paths(args.folder, args.recursive))
+    emit_status("queued", len(files))
+
+    max_workers = args.max_workers if args.max_workers > 0 else (os.cpu_count() or 4)
+    processed = 0
+    total_hits = 0
+    start = time.time()
+
+    def worker(p: str):
+        emit_status("current", p)
+        try:
+            return p, scan_file(p, matcher, args, ext_filter)
+        except Exception as exc:  # pragma: no cover - unexpected
+            warn_once(f"file:{p}", f"処理失敗: {p} ({exc})")
+            return p, 0
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(worker, p): p for p in files}
+        for fut in as_completed(futures):
+            path = futures[fut]
+            try:
+                _, hits = fut.result()
+            except Exception as exc:  # pragma: no cover - already handled
+                warn_once(f"future:{path}", f"処理中に例外: {path} ({exc})")
+                hits = 0
+            processed += 1
+            total_hits += hits
+            emit_status("progress", processed, total_hits, path)
+
+    elapsed = time.time() - start
+    emit_status("done", processed, total_hits, f"{elapsed:.3f}")
+
 
 if __name__ == "__main__":
     main()

--- a/FastFileFinder/README.md
+++ b/FastFileFinder/README.md
@@ -1,0 +1,55 @@
+# FastFileFinder
+
+FastFileFinder は Python 製スキャナ `fastfilefinder_scan.py` を WinForms フロントエンドから操作し、大量のドキュメントの全文検索を高速に行うための Windows デスクトップツールです。C# 側は .NET Framework 4.8 / C# 7.3 を対象とし、Python スクリプトは UTF-8 の TSV を逐次出力します。
+
+## 主な機能
+
+- プレーンテキスト・ソースコード・ログ・ZIP 内テキストを対象とした高速検索
+- Word (.docx) / Excel (.xlsx) の本文・セル検索（オプションで .doc / .xls も）
+- スレッドプールによる並列スキャンと逐次ストリーミング出力
+- 1 ファイルあたりのヒット上限 (`--perfile`) や並列度 (`--max-workers`) の制御
+- VirtualMode 対応 DataGridView による大量件数のスムーズな表示
+- 検索語のスニペットハイライト、並べ替え、クイックフィルタ、右クリックメニュー
+- 進捗表示（経過時間 / 処理済みファイル数 / ヒット件数 / 処理中ファイル）とキーボードショートカット（Enter/F5/Ctrl+C/Esc）
+- CSV/TSV エクスポート、エクスプローラー選択表示、パスコピー
+
+## ビルドと実行
+
+1. Visual Studio 2019 以降でソリューションを開き、`FastFileFinder` プロジェクトをビルドします（.NET Framework 4.8）。
+2. 実行ファイルと同じフォルダに `fastfilefinder_scan.py` が自動コピーされます。
+3. Python 3.8 以降をインストールし、以下のパッケージを必要に応じて導入します。
+   ```bash
+   pip install python-docx openpyxl
+   pip install pywin32   # 旧形式 .doc/.xls を検索する場合（要 Microsoft Office）
+   ```
+4. アプリ起動後、起点フォルダ・検索語などを設定し、必要に応じて以下を切り替えます。
+   - ZIP 内も検索
+   - Word (.docx) / Excel (.xlsx) / 旧形式 (.doc/.xls)
+   - サブフォルダ検索、正規表現検索
+   - 対象拡張子フィルタ、1 ファイル上限、並列度
+5. 「検索開始」または Enter/F5 でスキャン開始。Esc または「キャンセル」で Python プロセスを停止できます。
+
+## Python スクリプトのコマンドライン引数
+
+```
+python fastfilefinder_scan.py --folder <dir> --query <text>
+    [--regex] [--zip] [--recursive]
+    [--exts "txt;log;cs"]
+    [--perfile N] [--max-workers N]
+    [--word] [--excel] [--legacy]
+```
+
+- `--word` / `--excel` はそれぞれ .docx / .xlsx を対象にします（既定 ON）。
+- `--legacy` を付けると .doc / .xls も試みます。`pywin32` と Microsoft Office がインストールされていない場合は自動的にスキップされ、警告のみ出力します。
+- 旧形式は COM オートメーション経由で処理するため、並列実行時は初回起動に時間が掛かる場合があります。
+
+## 既知の制限
+
+- .docx/.xlsx 以外の ZIP 内 Office 文書は非対応です。
+- `pywin32` / Office が存在しない環境では .doc/.xls はスキップされます。
+- 正規表現ハイライトは先頭マッチのみ強調されます。文字列検索では全一致箇所をハイライトします。
+- 大量ファイルの並列実行時は Python 側の標準エラーに警告が出力される場合があります（UI 下部ステータスに表示）。
+
+## ライセンス
+
+本リポジトリに含まれるコードの利用条件はリポジトリの LICENSE（存在する場合）を参照してください。


### PR DESCRIPTION
## Summary
- extend the Python scanner with docx/xlsx parsing, optional legacy COM handling, status events, and thread pool concurrency controls
- rebuild the WinForms front-end with a flat light theme, Office/search option checkboxes, VirtualMode grid with highlighting, progress indicators, and CSV/TSV export improvements
- document setup, Python dependencies, and known limitations in a new README

## Testing
- python3 -m py_compile fastfilefinder_scan.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fc74bcc48322aab33f7b769644b1