### PR TITLE
Improve FastFileFinder responsiveness and scanner output

### DIFF
--- a/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
+++ b/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
@@ -44,7 +44,7 @@ ENCODINGS = (
 # Ensure stdout is UTF-8
 try:
     if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace", line_buffering=True)
 except Exception:
     pass
 
@@ -392,6 +392,7 @@ def main() -> None:
     emit_status("queued", len(files))
 
     max_workers = args.max_workers if args.max_workers > 0 else (os.cpu_count() or 4)
+    max_workers = max(1, max_workers)
     processed = 0
     total_hits = 0
     start = time.time()


### PR DESCRIPTION
## Summary
- queue scanner output and batch DataGridView updates via timers to keep the WinForms UI responsive while preserving virtualized rendering, quick filtering, and progress displays
- harden process lifecycle management, cancellation, and error reporting, including an error log tooltip and copy command
- enforce UTF-8 line-buffered stdout and clamp worker counts in fastfilefinder_scan.py while maintaining Office document support

## Testing
- dotnet build FastFileFinder.sln *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d606c1d79883229602a8ad48714edd