### PR TITLE
Fix backslash escaping in QuoteArgument helper

### DIFF
--- a/FastFileFinder/FastFileFinder/Form1.cs
+++ b/FastFileFinder/FastFileFinder/Form1.cs
@@ -955,7 +955,7 @@ namespace FastFileFinder
                 }
                 else if (c == '\"')
                 {
-                    sb.Append('\', backslashes * 2 + 1);
+                    sb.Append('\\', backslashes * 2 + 1);
                     sb.Append(c);
                     backslashes = 0;
                 }
@@ -963,7 +963,7 @@ namespace FastFileFinder
                 {
                     if (backslashes > 0)
                     {
-                        sb.Append('\', backslashes);
+                        sb.Append('\\', backslashes);
                         backslashes = 0;
                     }
                     sb.Append(c);
@@ -972,7 +972,7 @@ namespace FastFileFinder
 
             if (backslashes > 0)
             {
-                sb.Append('\', backslashes * 2);
+                sb.Append('\\', backslashes * 2);
             }
 
             sb.Append('\"');


### PR DESCRIPTION
## Summary
- correct the QuoteArgument helper to escape backslash characters using valid C# 7.3 syntax
- ensure the generated character literals compile under the target language version

## Testing
- not run (environment only includes .NET Framework project)


------
https://chatgpt.com/codex/tasks/task_e_68d62b493d308322948e40cef5760f03