### PR TITLE
Improve legacy .doc conversion reliability

### DIFF
--- a/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
+++ b/FastFileFinder/FastFileFinder/fastfilefinder_scan.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import platform
 import re
 import sys
 import threading
@@ -11,7 +12,7 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import TextIOWrapper
 from zipfile import BadZipFile, ZipFile
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 # Optional dependencies
 try:  # python-docx for .docx
@@ -42,12 +43,14 @@ try:  # xlrd for legacy .xls (requires <=1.2)
 except Exception:  # pragma: no cover - dependency may be missing
     xlrd = None  # type: ignore
 
-try:  # pywin32 for legacy .doc via Word COM
+try:  # pywin32 for legacy .doc via Word COM (Office と Python のビット数 32/64 を一致させる必要あり)
     import pythoncom  # type: ignore
     import win32com.client  # type: ignore
+    import pywintypes  # type: ignore
 except Exception:  # pragma: no cover - dependency may be missing
     pythoncom = None  # type: ignore
     win32com = None  # type: ignore
+    pywintypes = None  # type: ignore
 
 # Required optional packages: python-docx, openpyxl, "xlrd<2.0", pywin32
 
@@ -69,6 +72,7 @@ except Exception:
     pass
 
 stdout_lock = threading.Lock()
+word_diag_lock = threading.Lock()
 warned = set()
 
 
@@ -88,8 +92,40 @@ def ensure_extended_path(path: str) -> str:
     return normalized
 
 
-def log_doc_warning(path: str, error: Exception) -> None:
-    message = f"⚠ .doc をテキストへ変換できませんでした: {path} ({error})"
+def _format_hresult(error: Exception) -> str:
+    hresult = getattr(error, "hresult", None)
+    if hresult is None:
+        return ""
+    if hresult < 0:
+        hresult &= 0xFFFFFFFF
+    return f", hresult=0x{hresult:08X}"
+
+
+def _summarize_open_args(args: Optional[dict]) -> str:
+    if not args:
+        return ""
+    show_keys = [
+        "ReadOnly",
+        "AddToRecentFiles",
+        "ConfirmConversions",
+        "Visible",
+        "Encoding",
+        "Revert",
+    ]
+    parts = []
+    for key in show_keys:
+        if key in args:
+            parts.append(f"{key}={args[key]}")
+    if not parts:
+        return ""
+    return ", args=" + ", ".join(parts)
+
+
+def log_doc_warning(path: str, error: Exception, last_args: Optional[dict] = None) -> None:
+    message = (
+        f"⚠ .doc をテキストへ変換できませんでした: {path} "
+        f"({error}{_format_hresult(error)}{_summarize_open_args(last_args)})"
+    )
     sys.stderr.write(message + "\n")
     sys.stderr.flush()
 
@@ -289,11 +325,139 @@ def scan_xlsx(path: str, matcher, perfile: int) -> int:
 
 
 WD_FORMAT_UNICODE_TEXT = 7
+MSO_AUTOMATION_SECURITY_FORCE_DISABLE = 3
+DOC_LOCK_RETRY_COUNT = 2
+DOC_LOCK_RETRY_DELAY = 0.6
+
+WORD_DIAGNOSTICS_EMITTED = False
+
+
+def _error_text(exc: Exception) -> str:
+    if pywintypes is not None and isinstance(exc, pywintypes.com_error):
+        try:
+            if len(exc.args) >= 2 and isinstance(exc.args[1], str) and exc.args[1]:
+                return exc.args[1]
+        except Exception:
+            pass
+    return str(exc)
+
+
+def _looks_like_eula_block(exc: Exception) -> bool:
+    text = _error_text(exc).lower()
+    return any(keyword in text for keyword in ["eula", "license", "ダイアログ", "dialog"])
+
+
+def _should_retry_lock(exc: Exception) -> bool:
+    hresult = getattr(exc, "hresult", None)
+    lock_codes = {
+        -2147024864,  # 0x80070020 sharing violation
+        -2146823117,  # Word specific sharing violation
+    }
+    if hresult in lock_codes:
+        return True
+    text = _error_text(exc).lower()
+    tokens = ["sharing violation", "being used", "in use", "使用中", "ロック", "locked"]
+    return any(token in text for token in tokens)
+
+
+def _emit_word_diagnostics(word) -> None:
+    global WORD_DIAGNOSTICS_EMITTED
+    with word_diag_lock:
+        if WORD_DIAGNOSTICS_EMITTED:
+            return
+        WORD_DIAGNOSTICS_EMITTED = True
+    try:
+        version = getattr(word, "Version", "unknown")
+    except Exception:
+        version = "unknown"
+    bitness = "unknown"
+    try:
+        os_info = str(word.System.OperatingSystem)
+        if "64" in os_info:
+            bitness = "64-bit"
+        elif "32" in os_info:
+            bitness = "32-bit"
+    except Exception:
+        pass
+    python_bits = platform.architecture()[0]
+    try:
+        pywin32_version = getattr(win32com.client, "__version__", "unknown")
+    except Exception:
+        pywin32_version = "unknown"
+    diag = (
+        f"WordDiag: word_version={version}; word_bitness={bitness}; "
+        f"python_bitness={python_bits}; pywin32={pywin32_version}"
+    )
+    sys.stderr.write(diag + "\n")
+    sys.stderr.flush()
+
+
+def _build_open_sequences(file_name: str) -> List[dict]:
+    base = {
+        "FileName": file_name,
+        "ReadOnly": True,
+        "AddToRecentFiles": False,
+        "ConfirmConversions": False,
+        "Visible": False,
+    }
+    sequences = [base.copy()]
+    for encoding in (65001, 1200):
+        args = base.copy()
+        args["Encoding"] = encoding
+        sequences.append(args)
+    revert = base.copy()
+    revert["Revert"] = True
+    sequences.append(revert)
+    for encoding in (65001, 1200):
+        args = base.copy()
+        args["Revert"] = True
+        args["Encoding"] = encoding
+        sequences.append(args)
+    return sequences
+
+
+def _try_open_document(word, candidates: List[str]) -> Tuple[Optional[object], Optional[dict], Optional[Exception]]:
+    last_args: Optional[dict] = None
+    last_error: Optional[Exception] = None
+    for attempt in range(DOC_LOCK_RETRY_COUNT + 1):
+        lock_retry_requested = False
+        for candidate in candidates:
+            for open_args in _build_open_sequences(candidate):
+                try:
+                    doc = word.Documents.Open(**open_args)
+                    return doc, open_args, None
+                except Exception as exc:  # pragma: no cover - depends on Word
+                    last_error = exc
+                    last_args = open_args
+                    if _should_retry_lock(exc):
+                        lock_retry_requested = True
+                        break
+            if lock_retry_requested:
+                break
+        if lock_retry_requested and attempt < DOC_LOCK_RETRY_COUNT:
+            time.sleep(DOC_LOCK_RETRY_DELAY)
+            continue
+        break
+    return None, last_args, last_error
+
+
+def _warn_word_launch_failure(exc: Exception) -> None:
+    reason = "Word を起動できません。Word がインストールされていない、または Office と Python のビット数 (32/64) が一致していない可能性があります。"
+    text = _error_text(exc).lower()
+    hresult = getattr(exc, "hresult", None)
+    if hresult in {-2147221005, -2147221164} or "class not registered" in text:
+        reason = "Word がインストールされていないか、Office と Python のビット数 (32/64) が一致していません。"
+    elif "server execution failed" in text or hresult in {-2146959355}:
+        reason = "Word の COM 自動化を開始できません。Office と Python のビット数 (32/64) を確認してください。"
+    warn_once("word_launch", f"{reason} ({exc}{_format_hresult(exc)})")
 
 
 def extract_doc_text(path: str) -> List[str]:
     if pythoncom is None or win32com is None:
-        warn_once("doc", "pywin32 がインストールされていないため .doc をスキップします")
+        warn_once(
+            "doc",
+            "pywin32 がインストールされていないため .doc をスキップします (必要に応じて 'python -m pywin32_postinstall -install' を実行してください)",
+        )
         return []
 
     original_path = path
@@ -301,71 +465,88 @@ def extract_doc_text(path: str) -> List[str]:
     word = None
     doc = None
     coinitialized = False
+    last_open_args: Optional[dict] = None
 
     try:
         pythoncom.CoInitialize()
         coinitialized = True
         try:
-            word = win32com.client.DispatchEx("Word.Application")
-        except Exception as exc:
-            log_doc_warning(original_path, exc)
+            word = win32com.client.gencache.EnsureDispatch("Word.Application")
+        except Exception as exc:  # pragma: no cover - depends on Word availability
+            _warn_word_launch_failure(exc)
             return []
 
-        word.Visible = False
-        word.DisplayAlerts = 0
+        try:
+            word.Visible = False
+        except Exception:
+            pass
+        try:
+            word.DisplayAlerts = 0
+        except Exception as exc:
+            warn_once("word_alerts", f"Word.DisplayAlerts を設定できません: {exc}{_format_hresult(exc)}")
+        else:
+            try:
+                _ = word.DisplayAlerts
+            except Exception as exc:
+                if _looks_like_eula_block(exc):
+                    warn_once(
+                        "word_eula",
+                        "Word の初回起動ダイアログ (EULA) が表示されている可能性があります。Word を手動で起動し、ライセンスに同意してください。",
+                    )
+
+        try:
+            constants = getattr(win32com.client, "constants", None)
+            if constants is not None:
+                security_value = getattr(constants, "msoAutomationSecurityForceDisable", MSO_AUTOMATION_SECURITY_FORCE_DISABLE)
+            else:
+                security_value = MSO_AUTOMATION_SECURITY_FORCE_DISABLE
+            word.AutomationSecurity = security_value
+        except Exception:
+            try:
+                word.AutomationSecurity = MSO_AUTOMATION_SECURITY_FORCE_DISABLE
+            except Exception:
+                pass
+
+        _emit_word_diagnostics(word)
 
         normalized_path = os.path.abspath(path)
-        target_candidates = []
+        candidates = []
+        seen = set()
+
+        def _add_candidate(candidate: str) -> None:
+            lowered = os.path.normcase(candidate)
+            if lowered not in seen:
+                seen.add(lowered)
+                candidates.append(candidate)
+
         preferred = ensure_extended_path(normalized_path)
-        target_candidates.append(preferred)
-        if preferred != normalized_path:
-            target_candidates.append(normalized_path)
+        _add_candidate(preferred)
+        _add_candidate(normalized_path)
+        _add_candidate(original_path)
 
-        doc = None
-        open_error: Optional[Exception] = None
-        for candidate in target_candidates:
-            try:
-                doc = word.Documents.Open(
-                    candidate,
-                    ReadOnly=True,
-                    AddToRecentFiles=False,
-                )
-                break
-            except TypeError as exc:
-                open_error = exc
-                try:
-                    doc = word.Documents.Open(candidate, ReadOnly=True)
-                    break
-                except Exception as retry_exc:
-                    open_error = retry_exc
-            except Exception as exc:
-                open_error = exc
-
+        doc, last_open_args, open_error = _try_open_document(word, candidates)
         if doc is None:
-            log_doc_warning(original_path, open_error or RuntimeError("Word.Documents.Open failed"))
+            log_doc_warning(original_path, open_error or RuntimeError("Word.Documents.Open failed"), last_open_args)
             return []
 
         fd, temp_raw = tempfile.mkstemp(suffix=".txt")
         os.close(fd)
         temp_path = os.path.abspath(temp_raw)
-        save_candidates = []
-        preferred_save = ensure_extended_path(temp_path)
-        save_candidates.append(preferred_save)
-        if preferred_save != temp_path:
-            save_candidates.append(temp_path)
+        save_target = ensure_extended_path(temp_path)
 
         try:
-            save_error: Optional[Exception] = None
-            for candidate in save_candidates:
-                try:
-                    doc.SaveAs2(candidate, FileFormat=WD_FORMAT_UNICODE_TEXT)
-                    save_error = None
-                    break
-                except Exception as exc:
-                    save_error = exc
-
-            if save_error is not None:
-                log_doc_warning(original_path, save_error)
+            try:
+                if hasattr(doc, "SaveAs2"):
+                    doc.SaveAs2(save_target, FileFormat=WD_FORMAT_UNICODE_TEXT)
+                else:
+                    doc.SaveAs(save_target, FileFormat=WD_FORMAT_UNICODE_TEXT)
+            except TypeError:
+                if hasattr(doc, "SaveAs2"):
+                    doc.SaveAs2(save_target, WD_FORMAT_UNICODE_TEXT)
+                else:
+                    doc.SaveAs(save_target, WD_FORMAT_UNICODE_TEXT)
+            except Exception as exc:
+                log_doc_warning(original_path, exc, last_open_args)
                 return []
         finally:
             try:
@@ -375,28 +556,13 @@ def extract_doc_text(path: str) -> List[str]:
             doc = None
 
         try:
-            read_candidates = []
-            preferred_read = ensure_extended_path(temp_path)
-            read_candidates.append(preferred_read)
-            if preferred_read != temp_path:
-                read_candidates.append(temp_path)
-
-            read_error: Optional[Exception] = None
-            for candidate in read_candidates:
-                try:
-                    with open(candidate, "r", encoding="utf-16") as reader:
-                        return reader.read().splitlines()
-                except Exception as exc:
-                    read_error = exc
-
-            if read_error is not None:
-                log_doc_warning(original_path, read_error)
-                return []
+            with open(temp_path, "r", encoding="utf-16", errors="replace") as reader:
+                return reader.read().splitlines()
         except Exception as exc:
-            log_doc_warning(original_path, exc)
+            log_doc_warning(original_path, exc, last_open_args)
             return []
     except Exception as exc:
-        log_doc_warning(original_path, exc)
+        log_doc_warning(original_path, exc, last_open_args)
         return []
     finally:
         if doc is not None:
@@ -410,17 +576,13 @@ def extract_doc_text(path: str) -> List[str]:
             except Exception:
                 pass
         if temp_path:
-            remove_candidates = []
-            preferred_remove = ensure_extended_path(temp_path)
-            remove_candidates.append(preferred_remove)
-            if preferred_remove != temp_path:
-                remove_candidates.append(temp_path)
-            for candidate in remove_candidates:
+            try:
+                os.remove(temp_path)
+            except Exception:
                 try:
-                    os.remove(candidate)
-                    break
+                    os.remove(ensure_extended_path(temp_path))
                 except Exception:
-                    continue
+                    pass
         if coinitialized:
             try:
                 pythoncom.CoUninitialize()


### PR DESCRIPTION
## Summary
- Harden the legacy .doc pipeline by disabling Word macros, extending long paths, and sequencing Documents.Open calls with encoding/revert fallbacks plus lock-aware retries
- Save legacy documents as UTF-16 text, read them safely in Python, and report failures with HRESULT/open arguments alongside a one-line environment diagnostic

## Testing
- python fastfilefinder_scan.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d63e8c865083228e180141b54082a7