### PR TITLE
Add .doc conversion fallbacks and extension column

### DIFF
--- a/FastFileFinder/FastFileFinder/Form1.Designer.cs
+++ b/FastFileFinder/FastFileFinder/Form1.Designer.cs
@@ -66,6 +66,7 @@ namespace FastFileFinder
             this.chkZip = new System.Windows.Forms.CheckBox();
             this.resultsGrid = new System.Windows.Forms.DataGridView();
             this.columnPath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.columnExt = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnEntry = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnLine = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.columnSnippet = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -535,6 +536,7 @@ namespace FastFileFinder
             this.resultsGrid.ColumnHeadersHeight = 36;
             this.resultsGrid.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.columnPath,
+            this.columnExt,
             this.columnEntry,
             this.columnLine,
             this.columnSnippet});
@@ -563,14 +565,21 @@ namespace FastFileFinder
             this.resultsGrid.CellMouseEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.ResultsGrid_CellMouseEnter);
             // 
             // columnPath
-            // 
+            //
             this.columnPath.FillWeight = 40F;
             this.columnPath.HeaderText = "Path";
             this.columnPath.Name = "columnPath";
             this.columnPath.ReadOnly = true;
-            // 
+            //
+            // columnExt
+            //
+            this.columnExt.FillWeight = 8F;
+            this.columnExt.HeaderText = "Ext";
+            this.columnExt.Name = "columnExt";
+            this.columnExt.ReadOnly = true;
+            //
             // columnEntry
-            // 
+            //
             this.columnEntry.FillWeight = 15F;
             this.columnEntry.HeaderText = "Entry";
             this.columnEntry.Name = "columnEntry";
@@ -764,6 +773,7 @@ namespace FastFileFinder
         private System.Windows.Forms.CheckBox chkZip;
         private System.Windows.Forms.DataGridView resultsGrid;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnPath;
+        private System.Windows.Forms.DataGridViewTextBoxColumn columnExt;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnEntry;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnLine;
         private System.Windows.Forms.DataGridViewTextBoxColumn columnSnippet;

--- a/FastFileFinder/FastFileFinder/Form1.cs
+++ b/FastFileFinder/FastFileFinder/Form1.cs
@@ -334,6 +334,9 @@ namespace FastFileFinder
                 case "columnPath":
                     comparison = (a, b) => string.Compare(_allResults[a].DisplayPath, _allResults[b].DisplayPath, StringComparison.OrdinalIgnoreCase);
                     break;
+                case "columnExt":
+                    comparison = (a, b) => string.Compare(_allResults[a].Extension, _allResults[b].Extension, StringComparison.OrdinalIgnoreCase);
+                    break;
                 case "columnEntry":
                     comparison = (a, b) => string.Compare(_allResults[a].Entry, _allResults[b].Entry, StringComparison.OrdinalIgnoreCase);
                     break;
@@ -363,6 +366,10 @@ namespace FastFileFinder
             if (e.ColumnIndex == columnPath.Index)
             {
                 e.Value = result.DisplayPath;
+            }
+            else if (e.ColumnIndex == columnExt.Index)
+            {
+                e.Value = result.Extension;
             }
             else if (e.ColumnIndex == columnEntry.Index)
             {
@@ -1148,7 +1155,10 @@ namespace FastFileFinder
             int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out int line);
             string snippet = parts[3];
 
-            var result = new SearchResult(path, ToDisplayPath(path), entry, line, snippet, BuildHighlights(snippet));
+            string extension = Path.GetExtension(path);
+            string extDisplay = string.IsNullOrEmpty(extension) ? string.Empty : extension.TrimStart('.');
+
+            var result = new SearchResult(path, ToDisplayPath(path), extDisplay, entry, line, snippet, BuildHighlights(snippet));
             _pendingResults.Enqueue(result);
         }
 
@@ -1448,10 +1458,11 @@ namespace FastFileFinder
 
         private sealed class SearchResult
         {
-            public SearchResult(string fullPath, string displayPath, string entry, int lineNumber, string snippet, IReadOnlyList<HighlightSpan> highlights)
+            public SearchResult(string fullPath, string displayPath, string extension, string entry, int lineNumber, string snippet, IReadOnlyList<HighlightSpan> highlights)
             {
                 FullPath = fullPath;
                 DisplayPath = displayPath;
+                Extension = extension ?? string.Empty;
                 Entry = entry;
                 LineNumber = lineNumber;
                 Snippet = snippet;
@@ -1460,6 +1471,7 @@ namespace FastFileFinder
 
             public string FullPath { get; }
             public string DisplayPath { get; }
+            public string Extension { get; }
             public string Entry { get; }
             public int LineNumber { get; }
             public string Snippet { get; }


### PR DESCRIPTION
## Summary
- implement .doc conversion fallback chain (Word COM, LibreOffice, antiword) with structured stderr diagnostics
- expose an Ext column in the results grid and allow sorting by extension
- document the new dependencies and .doc fallback flow in the README

## Testing
- python -m compileall FastFileFinder/fastfilefinder_scan.py
- python FastFileFinder/fastfilefinder_scan.py --help


------
https://chatgpt.com/codex/tasks/task_e_68d644adf54083228274c9b4093dc53c