### PR TITLE
Ensure COM-first legacy .doc conversion

### DIFF
--- a/FastFileFinder/FastFileFinder/Form1.cs
+++ b/FastFileFinder/FastFileFinder/Form1.cs
@@ -1042,6 +1042,11 @@ namespace FastFileFinder
             if (chkLegacy.Checked)
             {
                 args.Add("--legacy");
+                if (chkWord.Checked)
+                {
+                    args.Add("--legacy-doc");
+                    args.Add("com");
+                }
             }
 
             return string.Join(" ", args.Select(QuoteArgument));


### PR DESCRIPTION
## Summary
- update the scanner so legacy .doc files use Word COM by default with clearer stage-specific error reporting and optional diagnostics
- add --legacy-doc and --diag command-line switches to control conversion behaviour and surface environment information
- adjust the WinForms launcher to request COM mode explicitly and document the new requirements in the README

## Testing
- python FastFileFinder/FastFileFinder/fastfilefinder_scan.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d652ba94448322b07f441df27473eb