### PR TITLE
Improve legacy .doc scanning reliability

### DIFF
--- a/FastFileFinder/FastFileFinder/Form1.cs
+++ b/FastFileFinder/FastFileFinder/Form1.cs
@@ -66,6 +66,7 @@ namespace FastFileFinder
 
         private string _statusMessage = string.Empty;
         private DateTime _statusMessageUntil = DateTime.MinValue;
+        private int _tsvDebugLinesLogged;
 
         public Form1()
         {
@@ -940,6 +941,7 @@ namespace FastFileFinder
             _currentFile = string.Empty;
             _statusMessage = string.Empty;
             _statusMessageUntil = DateTime.MinValue;
+            _tsvDebugLinesLogged = 0;
 
             _stopwatch.Reset();
             _stopwatch.Start();
@@ -1261,6 +1263,20 @@ namespace FastFileFinder
             if (parts.Length < 4)
             {
                 return;
+            }
+
+            if (_tsvDebugLinesLogged < 10)
+            {
+                int index = Interlocked.Increment(ref _tsvDebugLinesLogged);
+                if (index <= 10)
+                {
+                    Debug.WriteLine($"[FastFileFinder TSV {index}] {e.Data}");
+                    if (index == 10)
+                    {
+                        BeginInvoke((Action)(() =>
+                            SetStatusMessage("TSVデバッグ: 最初の10行をデバッグ出力しました", TimeSpan.FromSeconds(6))));
+                    }
+                }
             }
 
             string path = parts[0];


### PR DESCRIPTION
## Summary
- harden the Word COM conversion path by adding staged logging, UTF-16 SaveAs polling, per-file diagnostics, and flushed TSV emission for .doc searches
- emit blank-entry TSV rows for .doc hits, log emit counts, and surface the first ten TSV lines via the WinForms debug log for easier verification
- update the README with the new diagnostics flow and troubleshooting guidance for legacy Word conversions

## Testing
- python -m py_compile FastFileFinder/FastFileFinder/fastfilefinder_scan.py

------
https://chatgpt.com/codex/tasks/task_e_68d657f484f083228b754b0c6f17122d